### PR TITLE
Support for Clone only objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gemino
-**A fast MPMC channel with predictable latency for rust!**
+**A MPMC channel**
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][doc-badge]][doc-url]
@@ -15,25 +15,15 @@
 ## What is Gemino
 Gemino is an implementation of a multi producer multi consumer (MPMC) broadcasting channel where all receivers have the 
 opportunity to receive all messages sent by all producers. The library has been designed with speed and ease of use in mind
-and offers both a blocking and asynchronous API which can be used at the same time. The design of the underlying data structure 
-was inspired by [LMAX Disruptor](https://lmax-exchange.github.io/disruptor/) but is simpler and has slightly fewer constraints.
+and offers both a blocking and asynchronous API which can be used at the same time.
 
 Gemino was developed as a personal learning exercise, but I believe it is good enough to share and use.
 > Gemino is still in very early development, is lacking rigorous testing and makes use of unsafe. Use at your own risk!
 
-## Why is it fast?
-1. It's built on a ring buffer which allows essentially wait free writes and wait free reads when data is available.
-2. It's "Lock-free". Gemino uses 2 atomic variables to handle synchronisation of senders and receivers.  
-3. Relaxed constraints. There is no guaranteed delivery of messages over gemino channels. If a receiver doesn't keep up it will miss out
-
 ## Why use Gemino?
-
-* You need a very fast buffered channel.
 * You need both async and blocking access to the same channel.
 * You need multiple receivers and senders but are not concerned with data loss if a receiver falls behind.
 * You need to be able to close the channel and have all parties be notified.
-* Your application can make use of bulk reads from receivers. 
-Bulk reads are a fast (and memory efficient) way to read messages compared to one at a time.
 
 ## Why not use Gemino?
 

--- a/benchmarks/src/async_benchmarks.rs
+++ b/benchmarks/src/async_benchmarks.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use super::*;
 
 async fn measure<FUT>(name: &str, runs: u32, f: impl Fn() -> FUT)
 where
@@ -7,10 +8,14 @@ where
     let mut average = 0;
     let mut min = u128::MAX;
     let mut max = 0;
-    for i in 0..runs {
+    for i in 0..runs + 3 {
         let start = std::time::Instant::now();
         f().await;
         let elapsed = start.elapsed().as_nanos();
+        if i < 3 {
+            //warmup
+            continue
+        }
         if i == 0 {
             average = elapsed
         } else {
@@ -59,6 +64,36 @@ async fn tokio_broadcast() {
 }
 
 #[tokio::test]
+async fn tokio_broadcast_struct() {
+    let num_to_write = 1000;
+    measure("tokio::broadcast - struct", 5, async || {
+        let test_data = gen_test_structs(num_to_write);
+        let (tx, mut rx) = tokio::sync::broadcast::channel(num_to_write + 10);
+        let writer = tokio::spawn(async move {
+            for i in test_data {
+                tx.send(i).expect("couldn't send value");
+            }
+        });
+        let reader = tokio::spawn(async move {
+            let mut results = Vec::with_capacity(num_to_write);
+            for _ in 0..num_to_write {
+                let value = rx
+                    .recv()
+                    .await
+                    .expect("got an error from tokio broadcast recv");
+                results.push(value);
+            }
+            results
+        });
+        let (_, results) = tokio::join!(writer, reader);
+        assert!(results.is_ok());
+        let results = results.unwrap();
+        assert_eq!(results.len(), num_to_write);
+    })
+        .await;
+}
+
+#[tokio::test]
 async fn gemino() {
     measure("gemino::Broadcast", 5, async || {
         let num_to_write = 1000;
@@ -86,6 +121,36 @@ async fn gemino() {
         assert_eq!(results.len(), num_to_write);
     })
     .await;
+}
+
+#[tokio::test]
+async fn gemino_struct() {
+    let num_to_write = 1000;
+    measure("gemino::broadcast - struct", 5, async || {
+        let test_data = gen_test_structs(num_to_write);
+        let (tx, mut rx) = gemino::channel(num_to_write + 10).expect("couldn't create channel");
+        let writer = tokio::spawn(async move {
+            for i in test_data {
+                tx.send(i).expect("couldn't send value");
+            }
+        });
+        let reader = tokio::spawn(async move {
+            let mut results = Vec::with_capacity(num_to_write);
+            for _ in 0..num_to_write {
+                let value = rx
+                    .recv_async_cloned()
+                    .await
+                    .expect("got an error from tokio broadcast recv");
+                results.push(value);
+            }
+            results
+        });
+        let (_, results) = tokio::join!(writer, reader);
+        assert!(results.is_ok());
+        let results = results.unwrap();
+        assert_eq!(results.len(), num_to_write);
+    })
+        .await;
 }
 
 #[tokio::test]
@@ -131,6 +196,48 @@ async fn tokio_broadcast_multi_reader() {
 }
 
 #[tokio::test]
+async fn tokio_broadcast_multi_reader_struct() {
+    let num_to_write = 1000;
+    measure("tokio::Broadcast - multi reader - struct", 5, async || {
+        let test_data = gen_test_structs(num_to_write);
+        let (tx, mut rx) = tokio::sync::broadcast::channel(num_to_write + 10);
+        let mut rx_clone = tx.subscribe();
+        let writer = tokio::spawn(async move {
+            for i in test_data {
+                tx.send(i).expect("couldn't send value");
+            }
+        });
+        let reader_a = tokio::spawn(async move {
+            let mut results = Vec::with_capacity(num_to_write);
+            for _ in 0..num_to_write {
+                let value = rx.recv().await.expect("got an error from gemino recv");
+                results.push(value);
+            }
+            results
+        });
+        let reader_b = tokio::spawn(async move {
+            let mut results = Vec::with_capacity(num_to_write);
+            for _ in 0..num_to_write {
+                let value = rx_clone
+                    .recv()
+                    .await
+                    .expect("got an error from gemino recv");
+                results.push(value);
+            }
+            results
+        });
+        let (_, results_a, results_b) = tokio::join!(writer, reader_a, reader_b);
+        assert!(results_a.is_ok());
+        assert!(results_b.is_ok());
+        let results_a = results_a.unwrap();
+        let results_b = results_b.unwrap();
+        assert_eq!(results_a.len(), num_to_write);
+        assert_eq!(results_b.len(), num_to_write);
+    })
+        .await;
+}
+
+#[tokio::test]
 async fn gemino_multi_reader() {
     measure("gemino::Broadcast - multi reader", 5, async || {
         let num_to_write = 1000;
@@ -173,4 +280,50 @@ async fn gemino_multi_reader() {
         assert_eq!(results_b.len(), num_to_write);
     })
     .await;
+}
+
+
+#[tokio::test]
+async fn gemino_multi_reader_struct() {
+    let num_to_write = 1000;
+    measure("gemino::Broadcast - multi reader - struct", 5, async || {
+        let test_data = gen_test_structs(num_to_write);
+        let (tx, mut rx) = gemino::channel(num_to_write + 10).expect("couldn't create channel");
+        let mut rx_clone = rx.clone();
+        let writer = tokio::spawn(async move {
+            for i in 0..num_to_write {
+                tx.send(i).expect("failed to send");
+            }
+        });
+        let reader_a = tokio::spawn(async move {
+            let mut results = Vec::with_capacity(num_to_write);
+            for _ in test_data {
+                let value = rx
+                    .recv_async()
+                    .await
+                    .expect("got an error from gemino recv");
+                results.push(value);
+            }
+            results
+        });
+        let reader_b = tokio::spawn(async move {
+            let mut results = Vec::with_capacity(num_to_write);
+            for _ in 0..num_to_write {
+                let value = rx_clone
+                    .recv_async()
+                    .await
+                    .expect("got an error from gemino recv");
+                results.push(value);
+            }
+            results
+        });
+        let (_, results_a, results_b) = tokio::join!(writer, reader_a, reader_b);
+        assert!(results_a.is_ok());
+        assert!(results_b.is_ok());
+        let results_a = results_a.unwrap();
+        let results_b = results_b.unwrap();
+        assert_eq!(results_a.len(), num_to_write);
+        assert_eq!(results_b.len(), num_to_write);
+    })
+        .await;
 }

--- a/benchmarks/src/async_benchmarks.rs
+++ b/benchmarks/src/async_benchmarks.rs
@@ -1,5 +1,5 @@
-use std::future::Future;
 use super::*;
+use std::future::Future;
 
 async fn measure<FUT>(name: &str, runs: u32, f: impl Fn() -> FUT)
 where
@@ -14,7 +14,7 @@ where
         let elapsed = start.elapsed().as_nanos();
         if i < 3 {
             //warmup
-            continue
+            continue;
         }
         if i == 0 {
             average = elapsed
@@ -90,7 +90,7 @@ async fn tokio_broadcast_struct() {
         let results = results.unwrap();
         assert_eq!(results.len(), num_to_write);
     })
-        .await;
+    .await;
 }
 
 #[tokio::test]
@@ -150,7 +150,7 @@ async fn gemino_struct() {
         let results = results.unwrap();
         assert_eq!(results.len(), num_to_write);
     })
-        .await;
+    .await;
 }
 
 #[tokio::test]
@@ -234,7 +234,7 @@ async fn tokio_broadcast_multi_reader_struct() {
         assert_eq!(results_a.len(), num_to_write);
         assert_eq!(results_b.len(), num_to_write);
     })
-        .await;
+    .await;
 }
 
 #[tokio::test]
@@ -282,7 +282,6 @@ async fn gemino_multi_reader() {
     .await;
 }
 
-
 #[tokio::test]
 async fn gemino_multi_reader_struct() {
     let num_to_write = 1000;
@@ -325,5 +324,5 @@ async fn gemino_multi_reader_struct() {
         assert_eq!(results_a.len(), num_to_write);
         assert_eq!(results_b.len(), num_to_write);
     })
-        .await;
+    .await;
 }

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,8 +1,6 @@
 #![feature(test)]
 #![feature(async_closure)]
 
-use std::sync::Arc;
-
 #[cfg(test)]
 mod async_benchmarks;
 #[cfg(test)]
@@ -10,21 +8,29 @@ mod parallel_benchmarks;
 #[cfg(test)]
 mod seq_benchmarks;
 
-#[derive(Clone, Eq, PartialEq, Debug)]
-struct TestMe {
-    a: u64,
-    b: String,
-    c: Arc<u64>
+#[cfg(test)]
+mod test_helpers {
+    use std::sync::Arc;
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    pub struct TestMe {
+        a: u64,
+        b: String,
+        c: Arc<u64>,
+    }
+
+    pub fn gen_test_structs(num: usize) -> Vec<TestMe> {
+        (0..num)
+            .map(|v| {
+                let t = TestMe {
+                    a: v as u64,
+                    b: format!("hello world {v}"),
+                    c: Arc::new((v as u64) + 1),
+                };
+                t
+            })
+            .collect()
+    }
 }
 
-fn gen_test_structs(num:usize) -> Vec<TestMe> {
-    (0..num).map(|v|{
-        let t = TestMe {
-            a: v as u64,
-            b: format!("hello world {v}"),
-            c: Arc::new((v as u64) + 1)
-        };
-        t
-    }).collect()
-}
-
+#[cfg(test)]
+pub use test_helpers::*;

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,9 +1,30 @@
 #![feature(test)]
 #![feature(async_closure)]
 
+use std::sync::Arc;
+
 #[cfg(test)]
 mod async_benchmarks;
 #[cfg(test)]
 mod parallel_benchmarks;
 #[cfg(test)]
 mod seq_benchmarks;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+struct TestMe {
+    a: u64,
+    b: String,
+    c: Arc<u64>
+}
+
+fn gen_test_structs(num:usize) -> Vec<TestMe> {
+    (0..num).map(|v|{
+        let t = TestMe {
+            a: v as u64,
+            b: format!("hello world {v}"),
+            c: Arc::new((v as u64) + 1)
+        };
+        t
+    }).collect()
+}
+

--- a/benchmarks/src/seq_benchmarks.rs
+++ b/benchmarks/src/seq_benchmarks.rs
@@ -1,13 +1,10 @@
 extern crate test;
 
-use std::sync::Arc;
+use super::*;
 use crossbeam_channel::{bounded, unbounded};
 use kanal::bounded as kanal_bounded;
 use std::sync::mpsc::channel;
 use test::Bencher;
-use super::*;
-
-
 
 #[bench]
 fn sequential_gemino(b: &mut Bencher) {
@@ -100,7 +97,7 @@ fn sequential_crossbeam_bounded_struct(b: &mut Bencher) {
 fn sequential_crossbeam_bounded_struct_test() {
     let test_data = gen_test_structs(10000);
     for _ in 0..100 {
-        let (producer, mut consumer) = bounded(100);
+        let (producer, consumer) = bounded(100);
         for i in &test_data {
             producer.send(i.clone()).expect("failed to send");
             let v = consumer.recv().expect("couldn't get value");

--- a/gemino/Cargo.toml
+++ b/gemino/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gemino"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description="A fast multi producer multi consumer (MPMC) broadcasting channel"
+description="A multi producer multi consumer (MPMC) broadcasting channel"
 readme = "../README.md"
 repository = "https://github.com/Lochlanna/gemino"
 homepage = "https://github.com/Lochlanna/gemino"

--- a/gemino/Cargo.toml
+++ b/gemino/Cargo.toml
@@ -14,8 +14,11 @@ exclude = ["/.*"]
 [dependencies]
 event-listener = {version = "2.5"}
 thiserror = "1.0"
+parking_lot = {version="0.12.1", optional = true}
 
 [features]
+default = ["clone"]
+clone=["parking_lot"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/gemino/src/channel.rs
+++ b/gemino/src/channel.rs
@@ -25,22 +25,6 @@ pub enum ChannelError {
     ReadTooLarge,
 }
 
-#[repr(transparent)]
-#[derive(Debug)]
-struct SyncUnsafeCell<T: ?Sized>(T);
-impl<T: ?Sized> SyncUnsafeCell<T> {
-    /// Gets a mutable pointer to the wrapped value.
-    ///
-    /// See [`UnsafeCell::get`] for details.
-    #[inline]
-    pub const fn raw_get(this: *const Self) -> *mut T {
-        // We can just cast the pointer from `SyncUnsafeCell<T>` to `T` because
-        // of #[repr(transparent)] on both SyncUnsafeCell and UnsafeCell.
-        // See UnsafeCell::raw_get.
-        this as *const T as *mut T
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct Channel<T> {
     inner: *mut Vec<T>,
@@ -473,7 +457,7 @@ where
 
         oldest = self.oldest();
         while from_id < oldest {
-            // we have to do this to ensure a wirter didn't overtake us before we could take out the lock.
+            // we have to do this to ensure a writer didn't overtake us before we could take out the lock.
             // inside this loop we play catch up if that happened. This will be expensive!
             from_id = oldest;
             start_idx = (from_id % self.capacity) as usize;

--- a/gemino/src/lib.rs
+++ b/gemino/src/lib.rs
@@ -576,6 +576,469 @@ where
     }
 }
 
+impl<T> Receiver<T> where T: Clone + 'static {
+    /// Receives the next value from the channel. This function will block until a new value is put onto the
+    /// channel or the channel is closed; even if there are no senders.
+    ///
+    /// # Errors
+    /// - [`Error::Lagged`] The receiver has fallen behind and the next value has already been overwritten.
+    /// The receiver has skipped forward to the oldest available value in the channel and the number of missed messages is returned
+    /// in the error.
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?;
+    /// let v = rx.recv()?;
+    /// assert_eq!(v, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn recv_cloned(&mut self) -> Result<T, Error> {
+        let id = self.next_id;
+        match self.inner.get_blocking_cloned(id) {
+            Ok(value) => {
+                self.next_id += 1;
+                Ok(value)
+            }
+            Err(err) => match err {
+                ChannelError::IdTooOld(oldest) => {
+                    self.next_id = oldest as usize;
+                    let missed = self.next_id - id;
+                    Err(Error::Lagged(missed))
+                }
+                ChannelError::Closed => Err(Error::Closed),
+                _ => panic!("unexpected error while receving from channel: {err}"),
+            },
+        }
+    }
+
+    /// Receives the next value from the channel before the timeout.
+    /// This function will block even if there are no senders.
+    ///
+    /// # Errors
+    /// - [`Error::Lagged`] The receiver has fallen behind and the next value has already been overwritten.
+    /// The receiver has skipped forward to the oldest available value in the channel and the number of missed messages is returned
+    /// in the error.
+    /// - [`Error::NoNewData`] No new data was put into the channel before the timeout.
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use std::time::Duration;
+    /// # use gemino::{channel, Error};
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?;
+    /// let v = rx.recv_before(Duration::from_millis(5))?;
+    /// assert_eq!(v, 42);
+    /// std::thread::spawn(move ||{
+    ///     std::thread::sleep(Duration::from_millis(6));
+    ///     tx.send(22).expect("cannot send");
+    /// });
+    /// let fail = rx.recv_before(Duration::from_millis(5));
+    /// assert!(fail.is_err());
+    /// assert!(matches!(fail.err().unwrap(), Error::NoNewData));
+    /// let v = rx.recv_before(Duration::from_millis(30))?;
+    /// assert_eq!(v, 22);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn recv_before_cloned(&mut self, timeout: core::time::Duration) -> Result<T, Error> {
+        let id = self.next_id;
+        match self
+            .inner
+            .get_blocking_before_cloned(id, Instant::now().add(timeout))
+        {
+            Ok(value) => {
+                self.next_id += 1;
+                Ok(value)
+            }
+            Err(err) => match err {
+                ChannelError::IdTooOld(oldest) => {
+                    self.next_id = oldest as usize;
+                    let missed = self.next_id - id;
+                    Err(Error::Lagged(missed))
+                }
+                ChannelError::Closed => Err(Error::Closed),
+                ChannelError::Timeout => Err(Error::NoNewData),
+                _ => panic!("unexpected error while receving from channel: {err}"),
+            },
+        }
+    }
+
+    /// Asynchronously receives the next value from the channel.
+    ///
+    /// # Errors
+    /// - [`Error::Lagged`] The receiver has fallen behind and the next value has already been overwritten.
+    /// The receiver has skipped forward to the oldest available value in the channel and the number of missed messages is returned
+    /// in the error.
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # async fn test()->Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?;
+    /// let v = rx.recv_async().await?;
+    /// assert_eq!(v, 42);
+    /// # Ok(())
+    /// # }
+    /// # fn main() -> Result<()> {
+    /// # tokio_test::block_on(test())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn recv_async_cloned(&mut self) -> Result<T, Error> {
+        let id = self.next_id;
+        match self.inner.get_cloned(id).await {
+            Ok(value) => {
+                self.next_id += 1;
+                Ok(value)
+            }
+            Err(err) => match err {
+                ChannelError::IdTooOld(oldest) => {
+                    self.next_id = oldest as usize;
+                    let missed = self.next_id - id;
+                    Err(Error::Lagged(missed))
+                }
+                ChannelError::Closed => Err(Error::Closed),
+                _ => panic!("unexpected error while receving from channel: {err}"),
+            },
+        }
+    }
+
+    /// Reads all new values from the channel into a vector. Bulk reads are very fast and memory
+    /// efficient as it does a direct memory copy into the target array and only has to do synchronisation
+    /// checks one time. In an environment where there is high write load this will be the best way to
+    /// read from the channel.
+    ///
+    /// This function does not block and does not fail. If there is no new data it does nothing. If there are missed messages the number
+    /// of missed messages will be returned. New values are appended to the given vector so it is the
+    /// responsibility of the caller to reset the vector.
+    ///
+    /// # Errors
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    /// - [`Error::NoNewData`] All messages on the channel have already been read by this receiver.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?; // This will be overwritten because the buffer size is only 2
+    /// tx.send(12)?;
+    /// tx.send(21)?;
+    /// let mut results = Vec::new();
+    /// let v = rx.try_recv_many(&mut results)?;
+    /// assert_eq!(v, 1); // We missed out on one message
+    /// assert_eq!(vec![12,21], results);
+    /// tx.send(5)?;
+    /// let v = rx.try_recv()?; // The receiver is now caught up to the latest value
+    /// assert_eq!(v, 5);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_recv_many_cloned(&mut self, result: &mut Vec<T>) -> Result<usize, Error> {
+        let (first_id, last_id) =
+            self.inner
+                .read_batch_from_cloned(self.next_id, result)
+                .or_else(|err| match err {
+                    ChannelError::IDNotYetWritten => Err(Error::NoNewData),
+                    ChannelError::Closed => Err(Error::Closed),
+                    _ => panic!("unexpected error while performing bulk read: {err}"),
+                })?;
+
+        let mut missed = 0;
+        if first_id as usize > self.next_id {
+            missed = first_id as usize - self.next_id
+        }
+        self.next_id = last_id as usize + 1;
+        Ok(missed)
+    }
+
+    /// Reads at least `num` new values from the channel into a vector. Bulk reads are very fast and memory
+    /// efficient as it does a direct memory copy into the target array and only has to do synchronisation
+    /// checks one time. In an environment where there is high write load this will be the best way to
+    /// read from the channel.
+    ///
+    /// This function will block until at least `num` elements are available to read from the channel.
+    ///
+    /// # Errors
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    /// - [`Error::NoNewData`] All messages on the channel have already been read by this receiver.
+    /// - [`Error::ReadTooLarge`] Request cannot be filled as the channel capacity is smaller than the requested number of elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let (tx, mut rx) = channel(3)?;
+    /// tx.send(42)?;
+    /// tx.send(12)?;
+    /// tx.send(21)?;
+    /// let mut results = Vec::new();
+    /// let v = rx.recv_at_least(2, &mut results)?;
+    /// assert_eq!(v, 0);
+    /// assert_eq!(vec![42, 12,21], results);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn recv_at_least_cloned(&mut self, num: usize, result: &mut Vec<T>) -> Result<usize, Error> {
+        let (first_id, last_id) = self
+            .inner
+            .read_at_least_cloned(num, self.next_id, result)
+            .or_else(|err| match err {
+                ChannelError::IDNotYetWritten => Err(Error::NoNewData),
+                ChannelError::Closed => Err(Error::Closed),
+                ChannelError::ReadTooLarge => Err(Error::ReadTooLarge),
+                _ => panic!("unexpected error while performing bulk read: {err}"),
+            })?;
+
+        let mut missed = 0;
+        if first_id as usize > self.next_id {
+            missed = first_id as usize - self.next_id
+        }
+        self.next_id = last_id as usize + 1;
+        Ok(missed)
+    }
+
+    /// Reads at least `num` new values from the channel into a vector. Bulk reads are very fast and memory
+    /// efficient as it does a direct memory copy into the target array and only has to do synchronisation
+    /// checks one time. In an environment where there is high write load this will be the best way to
+    /// read from the channel.
+    ///
+    /// This function will wait until at least `num` elements are available to read from the channel.
+    ///
+    /// # Errors
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    /// - [`Error::NoNewData`] All messages on the channel have already been read by this receiver.
+    /// - [`Error::ReadTooLarge`] Request cannot be filled as the channel capacity is smaller than the requested number of elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # use std::time::Duration;
+    /// # async fn test() -> Result<()> {
+    /// let (tx, mut rx) = channel(3)?;
+    /// tx.send(42)?;
+    /// tx.send(12)?;
+    /// let mut results = Vec::new();
+    /// let fail = tokio::time::timeout(Duration::from_millis(5), rx.recv_at_least_async(3, &mut results)).await;
+    /// assert!(fail.is_err()); // timeout because it was waiting for 3 elements on the array
+    /// tx.send(21)?;
+    /// let v = rx.recv_at_least_async(3, &mut results).await?;
+    /// assert_eq!(v, 0);
+    /// assert_eq!(vec![42, 12, 21], results);
+    /// # Ok(())
+    /// # }
+    /// # fn main() -> Result<()> {
+    /// # tokio_test::block_on(test())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn recv_at_least_async_cloned(
+        &mut self,
+        num: usize,
+        result: &mut Vec<T>,
+    ) -> Result<usize, Error> {
+        let (first_id, last_id) = self
+            .inner
+            .read_at_least_async_cloned(num, self.next_id, result)
+            .await
+            .or_else(|err| match err {
+                ChannelError::IDNotYetWritten => Err(Error::NoNewData),
+                ChannelError::Closed => Err(Error::Closed),
+                ChannelError::ReadTooLarge => Err(Error::ReadTooLarge),
+                _ => panic!("unexpected error while performing bulk read: {err}"),
+            })?;
+
+        let mut missed = 0;
+        if first_id as usize > self.next_id {
+            missed = first_id as usize - self.next_id
+        }
+        self.next_id = last_id as usize + 1;
+        Ok(missed)
+    }
+
+    /// Attempt to retrieve the next value from the channel immediately. This function will not block.
+    ///
+    /// As with [`Receiver::recv`] if the receiver is running behind so far that it hasn't read values before they're overwritten
+    /// `Error::Lagged` is returned along with the number of values the receiver has missed. The receiver is then updated
+    /// so that the next call to any recv function will return the oldest value on the channel.
+    ///
+    ///
+    /// # Errors
+    /// - [`Error::Lagged`] The receiver has fallen behind and the next value has already been overwritten.
+    /// The receiver has skipped forward to the oldest available value in the channel and the number of missed messages is returned
+    /// in the error.
+    /// - [`Error::NoNewData`] There is no new data on the channel to be received.
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?;
+    /// let v = rx.try_recv()?;
+    /// assert_eq!(v, 42);
+    /// assert!(rx.try_recv().is_err());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_recv_cloned(&mut self) -> Result<T, Error> {
+        let id = self.next_id;
+        match self.inner.try_get_cloned(id) {
+            Ok(value) => {
+                self.next_id += 1;
+                Ok(value)
+            }
+            Err(err) => {
+                match err {
+                    ChannelError::IdTooOld(oldest_valid_id) => {
+                        //lagged
+                        self.next_id = oldest_valid_id as usize;
+                        let missed = oldest_valid_id as usize - id;
+                        Err(Error::Lagged(missed))
+                    }
+                    ChannelError::Closed => Err(Error::Closed),
+                    ChannelError::IDNotYetWritten => Err(Error::NoNewData),
+                    _ => panic!("unexpected error while receiving value from channel: {err}"),
+                }
+            }
+        }
+    }
+
+    fn try_latest_cloned(&mut self) -> Result<(T, isize), Error> {
+        self.inner.get_latest_cloned().or_else(|err| match err {
+            ChannelError::Overloaded => Err(Error::Overloaded),
+            ChannelError::IDNotYetWritten => Err(Error::NoNewData),
+            ChannelError::Closed => Err(Error::Closed),
+            _ => panic!("unexpected data while getting latest value from channel: {err}"),
+        })
+    }
+
+    /// Get the latest value from the channel unless it has already been read in which case wait (blocking)
+    /// for the next value to be put onto the channel.
+    /// This will cause the receiver to skip forward to the most recent value meaning that recv will get
+    /// the next latest value.
+    ///
+    ///
+    /// # Errors
+    /// - [`Error::NoNewData`]The channel has not been written to yet.
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    /// - [`Error::Overloaded`] The channel is being written to so quickly that the entire channel is being
+    /// written before a read can take place. This should be very rare and should only really be possible in
+    /// scenarios where there is extremely high right load on an extremely small buffer. Either make the buffer bigger
+    /// or slow the senders.
+    /// # Example
+    ///
+    /// ```rust
+    /// # use std::thread;
+    /// # use std::time::Duration;
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?;
+    /// let v = rx.latest()?;
+    /// assert_eq!(v, 42);
+    /// thread::spawn(move || {
+    ///     thread::sleep(Duration::from_secs_f32(0.1));
+    ///     tx.send(72).expect("couldn't send");
+    /// });
+    /// let v = rx.latest()?;
+    /// assert_eq!(v, 72);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn latest_cloned(&mut self) -> Result<T, Error> {
+        let (value, id) = self.try_latest_cloned()?;
+        if (id as usize) < self.next_id {
+            return self.recv_cloned();
+        }
+        self.next_id = id as usize + 1;
+        Ok(value)
+    }
+
+    /// Get the latest value from the channel unless it has already been read in which case wait (async)
+    /// for the next value to be put onto the channel.
+    /// This will cause the receiver to skip forward to the most recent value meaning that recv will get
+    /// the next latest value.
+    ///
+    ///
+    /// # Errors
+    /// - [`Error::NoNewData`]The channel has not been written to yet.
+    /// - [`Error::Closed`] The channel has been closed by a sender. All subsequent calls to this function
+    /// will also return this error.
+    /// - [`Error::Overloaded`] The channel is being written to so quickly that the entire channel is being
+    /// written before a read can take place. This should be very rare and should only really be possible in
+    /// scenarios where there is extremely high right load on an extremely small buffer. Either make the buffer bigger
+    /// or slow the senders.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use std::time::Duration;
+    /// # use gemino::channel;
+    /// # use anyhow::Result;
+    /// # async fn test() -> Result<()> {
+    /// let (tx, mut rx) = channel(2)?;
+    /// tx.send(42)?;
+    /// let v = rx.latest_async().await?;
+    /// assert_eq!(v, 42);
+    /// tokio::spawn(async move {
+    ///     tokio::time::sleep(Duration::from_secs_f32(0.1)).await;
+    ///     tx.send(72).expect("couldn't send");
+    /// });
+    /// let v = rx.latest_async().await?;
+    /// assert_eq!(v, 72);
+    /// # Ok(())
+    /// # }
+    ///
+    /// # fn main() -> Result<()> {
+    /// # tokio_test::block_on(test())?;
+    /// # Ok(())
+    /// # }
+    ///
+    /// ```
+    pub async fn latest_async_cloned(&mut self) -> Result<T, Error> {
+        let (value, id) = self.try_latest_cloned()?;
+        if (id as usize) < self.next_id {
+            return self.recv_async_cloned().await;
+        }
+        self.next_id = id as usize + 1;
+        Ok(value)
+    }
+}
+
 impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
         Self {
@@ -746,7 +1209,7 @@ impl<T> From<Receiver<T>> for Sender<T> {
 /// # Ok(())
 /// # }
 /// ```
-pub fn channel<T: Copy + 'static>(buffer_size: usize) -> Result<(Sender<T>, Receiver<T>), Error> {
+pub fn channel<T: 'static>(buffer_size: usize) -> Result<(Sender<T>, Receiver<T>), Error> {
     let chan = Channel::new(buffer_size).or_else(|err| match err {
         ChannelError::BufferTooSmall => Err(Error::BufferTooSmall),
         ChannelError::BufferTooBig => Err(Error::BufferTooBig),

--- a/gemino/src/lib.rs
+++ b/gemino/src/lib.rs
@@ -577,7 +577,10 @@ where
 }
 
 #[cfg(feature = "clone")]
-impl<T> Receiver<T> where T: Clone + 'static {
+impl<T> Receiver<T>
+where
+    T: Clone + 'static,
+{
     /// Receives the next value from the channel. This function will block until a new value is put onto the
     /// channel or the channel is closed; even if there are no senders.
     ///
@@ -757,14 +760,14 @@ impl<T> Receiver<T> where T: Clone + 'static {
     /// # }
     /// ```
     pub fn try_recv_many_cloned(&mut self, result: &mut Vec<T>) -> Result<usize, Error> {
-        let (first_id, last_id) =
-            self.inner
-                .read_batch_from_cloned(self.next_id, result)
-                .or_else(|err| match err {
-                    ChannelError::IDNotYetWritten => Err(Error::NoNewData),
-                    ChannelError::Closed => Err(Error::Closed),
-                    _ => panic!("unexpected error while performing bulk read: {err}"),
-                })?;
+        let (first_id, last_id) = self
+            .inner
+            .read_batch_from_cloned(self.next_id, result)
+            .or_else(|err| match err {
+                ChannelError::IDNotYetWritten => Err(Error::NoNewData),
+                ChannelError::Closed => Err(Error::Closed),
+                _ => panic!("unexpected error while performing bulk read: {err}"),
+            })?;
 
         let mut missed = 0;
         if first_id as usize > self.next_id {
@@ -804,7 +807,11 @@ impl<T> Receiver<T> where T: Clone + 'static {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn recv_at_least_cloned(&mut self, num: usize, result: &mut Vec<T>) -> Result<usize, Error> {
+    pub fn recv_at_least_cloned(
+        &mut self,
+        num: usize,
+        result: &mut Vec<T>,
+    ) -> Result<usize, Error> {
         let (first_id, last_id) = self
             .inner
             .read_at_least_cloned(num, self.next_id, result)

--- a/gemino/src/lib.rs
+++ b/gemino/src/lib.rs
@@ -576,6 +576,7 @@ where
     }
 }
 
+#[cfg(feature = "clone")]
 impl<T> Receiver<T> where T: Clone + 'static {
     /// Receives the next value from the channel. This function will block until a new value is put onto the
     /// channel or the channel is closed; even if there are no senders.

--- a/gemino/src/tests.rs
+++ b/gemino/src/tests.rs
@@ -377,7 +377,6 @@ fn entire_buffer_batch() {
     assert_eq!(vec![42, 21, 12], results);
 }
 
-
 #[test]
 fn string_test() {
     let chan = Channel::new(1).expect("couldn't create channel");
@@ -394,18 +393,17 @@ fn struct_test() {
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct TestMe {
         a: u8,
-        b: String
+        b: String,
     }
     let t = TestMe {
         a: 42,
-        b: String::from("hello world")
+        b: String::from("hello world"),
     };
     let chan = Channel::new(1).expect("couldn't create channel");
     chan.send(t.clone()).expect("couldnt' send message");
     let res = chan.try_get_cloned(0).expect("couldn't get the value");
     assert_eq!(t, res);
 }
-
 
 #[test]
 fn drop_test() {


### PR DESCRIPTION
This PR brings support for safely using Gemino channels with structs that only support Clone. Without this it's not possible to safely send any objects which point to anything on the heap.

Supporting Clone slows things down significantly since it isn't using simple memcpy's.
The API is designed in such a way that there should be minimal slow down if you are using objects that implement Copy as long as you're choosing to use the correct API